### PR TITLE
(#4) - pouchdb-wrappers based port

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "es3ify": "^0.1.3",
     "inherits": "^2.0.1",
     "lie": "^2.6.0",
-    "pouchdb-extend": "^0.1.0"
+    "pouchdb-extend": "^0.1.0",
+    "pouchdb-wrappers": "^1.2.0"
   },
   "devDependencies": {
     "bluebird": "^1.0.7",


### PR DESCRIPTION
My shot at porting filter-pouch to use my [pouchdb-wrappers](https://www.npmjs.org/package/pouchdb-wrappers) lib.

Advantages:
- Less code
- More supported function signatures (`db.put({}, "id", 'rev")` e.g.)

Disadvantage:
- An extra dependency, with a codebase you probably aren't currently familiar with. (I'm currently open to bug reports/questions/suggestions, but it's not the same.)

If the advantages outweight the disadvantages I don't know, it's in the end your lib to maintain. Tests still pass without any modifications, coverage is still 100%.
