### PR TITLE
Fix cancel() of sync mapping bug since results is not returned

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,10 +131,13 @@ exports.transform = exports.filter = function transform(config) {
     }
 
     function modifyChanges(res) {
-      return utils.Promise.all(res.results.map(modifyChange)).then(function (results) {
-        res.results = results;
-        return res;
-      });
+      if (res.results) {
+        return utils.Promise.all(res.results.map(modifyChange)).then(function (results) {
+          res.results = results;
+          return res;
+        });
+      }
+      return utils.Promise.resolve(res);
     }
 
     var changes = orig();

--- a/test/test.js
+++ b/test/test.js
@@ -258,6 +258,12 @@ function tests(dbName, dbType) {
       });
     });
 
+    it('handles cancel', function () {
+        db.transform();
+        var syncHandler = db.sync('my_gateway', {});
+        return syncHandler.cancel();
+    });
+
     it('transforms on GET with options', function () {
       db.transform({
         outgoing: function (doc) {


### PR DESCRIPTION
For the cancel() method of the pouchdb it seems that the cancel() method of the sync gateway does not return a "results" - since it doesn't have any results. In that case it happens that for example crypto-pouch  is not working correctly because it's an .map of undefined. This PR checks if results available and only in that case the map is executed.